### PR TITLE
Add a basic `pyproject.toml` to allow building from source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin>=0.12,<0.13"]
+build-backend = "maturin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"
+
+[tool.maturin]
+sdist-include = ["Cargo.lock"]


### PR DESCRIPTION
Adds a bare-minimum `pyproject.toml` file as [detailed here](https://github.com/PyO3/maturin#source-distribution) to allow `pip` to build the rust jaeger reporter from source. This allows this package to be installed alongside python interpreters other than CPython (i.e. Pyston).

PS: I'm not sure if any other options are necessary, though testing building locally, installing and then running with a local Synapse works.

Version bounds are based on maturin's current version of v0.12.18.