### PR TITLE
Make host and port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ config = Config(
 )
 
 # Create the rust reporter.
-reporter = Reporter()
+reporter = Reporter(config={"agent_host_name": "127.0.0.1", "agent_port": 6831})
 
 # Create the tracer and install it as the global tracer.
 #
@@ -37,12 +37,6 @@ tracer = config.create_tracer(reporter, config.sampler)
 opentracing.set_global_tracer(tracer)
 
 ```
-
-Limitations
------------
-
-The reporter is not configurable and is hardcoded to report to the local agent
-on localhost and the default port.
 
 
 Building

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 sdist-include = ["Cargo.lock"]
+
+# Optional Dependencies
+# ---------------------
+objgraph = { version = ">=3.5.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,16 +85,17 @@ impl Reporter {
         let mut agent_port: i32 = 6831;
 
         if let Some(config) = config {
-            agent_host_name = config
-                .get_item("agent_host_name")
-                .unwrap()
-                .extract()
-                .unwrap_or("127.0.0.1".to_string());
-            agent_port = config
-                .get_item("agent_port")
-                .unwrap()
-                .extract()
-                .unwrap_or(6831);
+            if let Some(agent_host_name_arg) = config.get_item("agent_host_name") {
+                agent_host_name = agent_host_name_arg.extract().map_err(|_| {
+                    pyo3::exceptions::PyTypeError::new_err("'agent_host_name' must be an string")
+                })?;
+            }
+
+            if let Some(agent_port_arg) = config.get_item("agent_port") {
+                agent_port = agent_port_arg.extract().map_err(|_| {
+                    pyo3::exceptions::PyTypeError::new_err("'agent_port' must be an int")
+                })?;
+            }
         }
         // Set up the UDP transport
         let socket = UdpSocket::bind(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,10 +96,6 @@ impl Reporter {
                 .extract()
                 .unwrap_or(6831);
         }
-        println!(
-            "config agent_host_name={} config.agent_port={}",
-            agent_host_name, agent_port
-        );
         // Set up the UDP transport
         let socket = UdpSocket::bind(
             &(49152..65535)

--- a/test.py
+++ b/test.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
             },
             # 'logging': True,
         },
-        service_name="your-app-name",
+        service_name="rust-jaeger-python-client-test",
     )
 
     tracer = config.create_tracer(reporter, config.sampler)


### PR DESCRIPTION
Make host and port configurable

```py
reporter = Reporter(config={"agent_host_name": "some-host", "agent_port": 9999})
```

Fixes https://github.com/matrix-org/synapse/pull/13399#discussion_r930461741

## Dev notes

```sh
$ source /Users/eric/Documents/github/element/synapse/.venv/bin/activate
$ pip install maturin
# builds the crate and installs it as a python module directly in the current virtualenv. Note that while maturin develop is faster, it doesn't support all the feature that running pip install after maturin build supports.
$ maturin develop

# Sends spans over to your local Jaeger instance
$ python test.py
```


References:

 - https://maturin.rs/
 - https://doc.rust-lang.org/rust-by-example/fn/methods.html
 - PyO3 bindings:
    - https://github.com/PyO3/pyo3/blob/main/guide/src/function.md
    - https://github.com/PyO3/pyo3/blob/main/guide/src/class.md
    - https://github.com/PyO3/pyo3/blob/main/guide/src/types.md